### PR TITLE
RDK-46920 : RDK Devicesettings update to add new setMixerLevels API 

### DIFF
--- a/include/dsAVDTypes.h
+++ b/include/dsAVDTypes.h
@@ -779,6 +779,12 @@ typedef enum _dsDisplayMatrixCoefficients_t
     dsDISPLAY_MATRIXCOEFFICIENT_MAX            ///< Out of range
 } dsDisplayMatrixCoefficients_t;
 
+typedef enum _dsAudioInput_t{
+    dsAudioInputPrimary = 0,  /// Primary Audio Input to audio mixer
+    dsAudioInputSystem,      /// System Audio Input to audio mixer
+    dsAudioInputMax          ///< Out of range
+} dsAudioInput_t;
+
 /* End of DSHAL_DISPLAY_TYPES doxygen group */
 /**
  * @}

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -762,6 +762,30 @@ dsError_t dsSetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool allmSupport);
  */
 dsError_t dsGetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool *allmSupport);
 
+/**
+ * @brief Sets the Mixer Volume level for the given gain
+ *
+ * This function sets the mixer volume level for either player/primary volume
+ *
+ * @param[in] gain     - Mixer gain value , (MIXGAIN_SYS/MIXGAIN_TTS)
+ * @param[in] volume - volume to be set (0 to 100)
+ *
+ * @return dsError_t                        - Status
+ * @retval dsERR_NONE                       - Success
+ * @retval dsERR_NOT_INITIALIZED            - Module is not initialised
+ * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+ * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+ * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ *
+ * @pre dsHdmiInInit() must be called before calling this API
+ *
+ * @warning  This API is Not thread safe
+ *
+ * @see dsSetAudioMixerLevels()
+ *
+ */
+
+dsError_t dsSetAudioMixerLevels (int gain, int volume);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Reason for change: To control both primary and player volume 
Test Procedure: Verify using the curl commands to set the volume 
Risks: Medium Priority: P1 
