### PR TITLE
Devicesettings update to add new setMixerLevels API

### DIFF
--- a/docs/pages/ds-hdmi-in_halSpec.md
+++ b/docs/pages/ds-hdmi-in_halSpec.md
@@ -170,7 +170,7 @@ The `caller` is expected to have complete control over the life cycle of the `HA
 
 2. The `caller` can call `dsHdmiInSelectPort()`, `dsHdmiInScaleVideo()`, `dsSetEdidVersion()` and `dsHdmiInSelectZoomMode()` to set the needed information.
 
-3. The `caller` can call `dsHdmiInGetNumberOfInputs()`, `dsHdmiInGetStatus()`, `dsGetEDIDBytesInfo()`, `dsIsHdmiARCPort()`, `dsGetHDMISPDInfo()`,  `dsGetEdidVersion()`, `dsGetAllmStatus()`, `dsGetSupportedGameFeaturesList()`, `dsGetAVLatency()` and `dsHdmiInGetCurrentVideoMode()` to query the needed information.
+3. The `caller` can call `dsHdmiInGetNumberOfInputs()`, `dsHdmiInGetStatus()`, `dsGetEDIDBytesInfo()`, `dsIsHdmiARCPort()`, `dsGetHDMISPDInfo()`,  `dsGetEdidVersion()`, `dsGetAllmStatus()`, `dsGetSupportedGameFeaturesList()`, `dsGetAVLatency()`, `dsSetAudioMixerLevels()` and `dsHdmiInGetCurrentVideoMode()` to query the needed information.
 
 4. Callbacks can be set with:
     - `dsHdmiInRegisterConnectCB()` - used when the HDMIin port connection status changes

--- a/include/dsAVDTypes.h
+++ b/include/dsAVDTypes.h
@@ -779,6 +779,12 @@ typedef enum _dsDisplayMatrixCoefficients_t
     dsDISPLAY_MATRIXCOEFFICIENT_MAX            ///< Out of range
 } dsDisplayMatrixCoefficients_t;
 
+typedef enum _dsAudioInput_t{
+    dsAudioInputPrimary = 0,  /// Primary Audio Input to audio mixer
+    dsAudioInputSystem,      /// System Audio Input to audio mixer
+    dsAudioInputMax          ///< Out of range
+} dsAudioInput_t;
+
 /* End of DSHAL_DISPLAY_TYPES doxygen group */
 /**
  * @}

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -762,6 +762,31 @@ dsError_t dsSetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool allmSupport);
  */
 dsError_t dsGetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool *allmSupport);
 
+/**
+ * @brief Sets the Mixer Volume level for the given input
+ *
+ * This function sets the mixer volume level for either player/primary volume
+ *
+ * @param[in] dsAudioInput_t  - dsAudioInputPrimary / dsAudioInputSystem
+ * @param[in] volume          - volume to be set (0 to 100)
+ *
+ * @return dsError_t                        - Status
+ * @retval dsERR_NONE                       - Success
+ * @retval dsERR_NOT_INITIALIZED            - Module is not initialised
+ * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+ * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+ * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ *
+ * @pre dsHdmiInInit() must be called before calling this API
+ * @pre dsHdmiInSelectPort (dsHdmiInPort_t Port, bool audioMix, dsVideoPlaneType_t evideoPlaneType,bool topMost) must be called with 
+ * audioMix = true
+ *
+ * @warning  This API is Not thread safe
+ *
+ *
+ */
+dsError_t dsSetAudioMixerLevels (dsAudioInput_t aInput, int volume);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
RDK-46920: RDK Devicesettings update to add new setMixerLevels API 
Reason for change: To control both primary and player volume 
Test Procedure: Verify using the curl commands to set the volume 
Risks: Medium Priority: P1