### PR TITLE
PR: RDKE-41 Enhance component versioning and standard build support

### DIFF
--- a/halif-devicesettings.pc
+++ b/halif-devicesettings.pc
@@ -1,0 +1,9 @@
+# Package Information for pkg-config
+prefix=/usr
+includedir=${prefix}/include
+
+Name: DSHALHeaders
+Description: DeviceSettings HAL Headers
+Version: 1.0.8
+Cflags: -I${includedir}/rdk/halif/ds-hal
+


### PR DESCRIPTION
Enhance component versioning and standard build support by decoupling the install directory restructuring.

**Problem:**

- There is no build time confirmation on which version of Header is available.
- There is a hard dependency on the path of headers while building. If https://github.com/rdk-e/meta-rdk-halif-headers/commit/6945d98238fd271852ef0fe949280cf503813808 similar change happens it breaks the build if respective changes are not made in other layers(vendor & middleware).

**How it helps:**
Newly introduced pkg-config file will have the header component version and standard build flow can detect it.
when pkg-config is having 2.0.0
```
VM2[26/Apr|17:46:31]git# pkg-config --cflags 'halif-devicesettings >= 2.0.0' --print-errors
Requested 'halif-devicesettings >= 2.0.0' but version of DSHALHeaders is 1.0.8
VM2[26/Apr|17:46:58]git#
```
when pkg-config is having 1.0.8
```
VM2[26/Apr|17:46:59]git# pkg-config --cflags 'halif-devicesettings >= 1.0.8' --print-errors
-I/home/amadha013/community/build-raspberrypi4-64-rdk-mc/tmp/work/raspberrypi4-64-rdk-mc-vendor-rdkmllib32-linux-gnueabi/lib32-devicesettings-hal-raspberrypi4/1.0.0-r0/lib32-recipe-sysroot/usr/include/rdk/halif/ds-hal
VM2[26/Apr|17:47:06]git#
```
When vendor or middleware component builds; it can do a standard find pkg-config step and get the respective header installation path provided by **_halif-devicesettings.pc_** even if it is non-standard location. This helps to decouple the compile flag modification required to match Problem statement 2 similar changes.
**One-time change required in meta-rdk-halif-headers**

Install the respective pkg-config file from meta-rdk-halif-headers recipe.
```
diff --git a/recipes-rdk-halif-headers/devicesettings/devicesettings-hal-headers.bb b/recipes-rdk-halif-headers/devicesettings/devicesettings-hal-headers.bb
index 0826887..d433e60 100644
--- a/recipes-rdk-halif-headers/devicesettings/devicesettings-hal-headers.bb
+++ b/recipes-rdk-halif-headers/devicesettings/devicesettings-hal-headers.bb
@@ -18,7 +18,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"

 SRC_URI = "${CMF_GITHUB_ROOT}/rdk-halif-device_settings;${CMF_GITHUB_SRC_URI_SUFFIX}"

-inherit allarch
+inherit allarch pkgconfig

 S = "${WORKDIR}/git"

@@ -35,6 +35,9 @@ ALLOW_EMPTY_${PN} = "1"
 do_install() {
     install -d ${D}${includedir}/rdk/halif/ds-hal
     install -m 0644 ${S}/include/*.h ${D}${includedir}/rdk/halif/ds-hal
+
+    install -d ${D}${libdir}/pkgconfig
+    install -m 0644 ${S}/../halif-devicesettings.pc ${D}${libdir}/pkgconfig/
 }

 do_install[vardepsexclude] += "S"
```