### PR TITLE
gh #39 Video Port architectural comments

### DIFF
--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -703,7 +703,7 @@ dsError_t dsGetMatrixCoefficients(intptr_t handle, dsDisplayMatrixCoefficients_t
 /**
  * @brief Gets the color depth value of specified video port.
  * 
- * For sink devices, this function returns the default color depth, which is 10.
+ * For sink devices, this function returns the default color depth, which is platform dependent.
  *
  * For source devices, this function is used to get the current color depth value of specified video port.
  * Typically for UHD resolution, the color depth is 10/12-bit, while for non-UHD resolutions, it is 8-bit
@@ -727,7 +727,7 @@ dsError_t dsGetColorDepth(intptr_t handle, unsigned int* color_depth);
 /**
  * @brief Gets the color space setting of specified video port.
  * 
- * For sink devices, this function returns the default color space setting, which is dsDISPLAY_COLORSPACE_RGB.
+ * For sink devices, this function returns the default color space setting, which is platform dependent.
  *
  * For source devices, this function is used to get the current color space setting of specified video port.
  * The color space is typically YCbCr.

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -114,6 +114,8 @@ extern "C" {
  * @retval dsERR_GENERAL                - Underlying undefined platform error
  * 
  * @warning  This API is Not thread safe.
+ *
+ * @post dsVideoPortTerm() must be called to release resources.
  * 
  * @see dsVideoPortTerm()
  */

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -683,6 +683,7 @@ dsError_t dsGetVideoEOTF(intptr_t handle, dsHDRStandard_t *video_eotf);
  * @brief Gets the current matrix coefficients value.
  * 
  * This function is used to get the current matrix coefficient value of the specified video port.
+ * For source devices, this function would return dsDISPLAY_MATRIXCOEFFICIENT_UNKNOWN  when TV is not connected.
  *
  * @param[in]  handle               - Handle of the video port returned from dsGetVideoPort()
  * @param[out] matrix_coefficients  - pointer to matrix coefficients value.  Please refer ::dsDisplayMatrixCoefficients_t
@@ -753,6 +754,7 @@ dsError_t dsGetColorSpace(intptr_t handle, dsDisplayColorSpace_t* color_space);
  * @brief Gets the quantization range of specified video port.
  * 
  * This function is used to get the quantization range of the specified video port.
+ * For source devices, this function would return dsDISPLAY_MATRIXCOEFFICIENT_UNKNOWN when TV is not connected.
  *
  * @param[in]  handle               - Handle of the video port returned from dsGetVideoPort()
  * @param[out] quantization_range   - pointer to quantization range.  Please refer ::dsDisplayQuantizationRange_t
@@ -912,6 +914,7 @@ dsError_t dsGetIgnoreEDIDStatus(intptr_t handle, bool* status);
  * @brief Sets the background color of the specified video port.
  *
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+ *
  * For source devices, this function sets the background color of the specified video port.
  *
  * @param[in] handle    - Handle of the video port returned from dsGetVideoPort()

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -706,7 +706,7 @@ dsError_t dsGetMatrixCoefficients(intptr_t handle, dsDisplayMatrixCoefficients_t
  * For sink devices, this function returns the default color depth, which is 10.
  *
  * For source devices, this function is used to get the current color depth value of specified video port.
- * For UHD resolution, the color depth is 12-bit, while for non-UHD resolutions, it is 8-bit
+ * Typically for UHD resolution, the color depth is 10/12-bit, while for non-UHD resolutions, it is 8-bit
  *
  * @param[in]  handle       - Handle of the video port returned from dsGetVideoPort()
  * @param[out] color_depth  - pointer to color depth values.Please refer :: dsDisplayColorDepth_t
@@ -937,7 +937,7 @@ dsError_t dsSetBackgroundColor(intptr_t handle, dsVideoBackgroundColor_t color);
  *
  * For source devices, this function is used to set/reset force HDR mode for the specified video port.
  * It forces and locks the HDMI output to a specified HDR mode regardless of the source content format,
- * until reset by calling the same API with dsHDRSTANDARD_NONE.
+ * if the mode dsHDRSTANDARD_NONE is set, then the HDMI output to follow source contnet format.
  *
  * @param[in] handle    - Handle of the video port returned from dsGetVideoPort()
  * @param[in] mode      - HDR mode to be forced.  Please refer ::dsHDRStandard_t
@@ -982,6 +982,7 @@ dsError_t dsColorDepthCapabilities(intptr_t handle, unsigned int *colorDepthCapa
  *
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  * For source devices, this function is used to get the preferred color depth of the specified video port.
+ * Typically for UHD resolution, the color depth is 10/12-bit, while for non-UHD resolutions, it is 8-bit.
  *
  * @param[in] handle        - Handle of the video port returned from dsGetVideoPort()
  * @param [out] colorDepth  - color depth value.  Please refer ::dsDisplayColorDepth_t

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -704,7 +704,9 @@ dsError_t dsGetMatrixCoefficients(intptr_t handle, dsDisplayMatrixCoefficients_t
  * @brief Gets the color depth value of specified video port.
  * 
  * For sink devices, this function returns the default color depth, which is 10.
+ *
  * For source devices, this function is used to get the current color depth value of specified video port.
+ * For UHD resolution, the color depth is 12-bit, while for non-UHD resolutions, it is 8-bit
  *
  * @param[in]  handle       - Handle of the video port returned from dsGetVideoPort()
  * @param[out] color_depth  - pointer to color depth values.Please refer :: dsDisplayColorDepth_t
@@ -726,7 +728,9 @@ dsError_t dsGetColorDepth(intptr_t handle, unsigned int* color_depth);
  * @brief Gets the color space setting of specified video port.
  * 
  * For sink devices, this function returns the default color space setting, which is dsDISPLAY_COLORSPACE_RGB.
+ *
  * For source devices, this function is used to get the current color space setting of specified video port.
+ * The color space is typically YCbCr.
  *
  * @param[in]  handle       - Handle of the video port returned from dsGetVideoPort()
  * @param[out] color_space  - pointer to color space value. Please refer ::dsDisplayColorSpace_t
@@ -818,6 +822,8 @@ dsError_t dsIsOutputHDR(intptr_t handle, bool* hdr);
  *
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  * For source devices, this function resets the video output to SDR.
+ * It forces and locks the HDMI output to SDR mode regardless of the source content format
+ * It forces and locks the HDMI output to SDR mode regardless of the source content format..
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success
@@ -928,7 +934,10 @@ dsError_t dsSetBackgroundColor(intptr_t handle, dsVideoBackgroundColor_t color);
  * @brief Sets/Resets the force HDR mode.
  *
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+ *
  * For source devices, this function is used to set/reset force HDR mode for the specified video port.
+ * It forces and locks the HDMI output to a specified HDR mode regardless of the source content format,
+ * until reset by calling the same API with dsHDRSTANDARD_NONE.
  *
  * @param[in] handle    - Handle of the video port returned from dsGetVideoPort()
  * @param[in] mode      - HDR mode to be forced.  Please refer ::dsHDRStandard_t

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -703,7 +703,8 @@ dsError_t dsGetMatrixCoefficients(intptr_t handle, dsDisplayMatrixCoefficients_t
 /**
  * @brief Gets the color depth value of specified video port.
  * 
- * This fundtion is used to get the current color depth value of specified video port.
+ * For sink devices, this function returns the default color depth, which is 10.
+ * For source devices, this function is used to get the current color depth value of specified video port.
  *
  * @param[in]  handle       - Handle of the video port returned from dsGetVideoPort()
  * @param[out] color_depth  - pointer to color depth values.Please refer :: dsDisplayColorDepth_t
@@ -724,7 +725,8 @@ dsError_t dsGetColorDepth(intptr_t handle, unsigned int* color_depth);
 /**
  * @brief Gets the color space setting of specified video port.
  * 
- * This function is used to get the current color space setting of specified video port.
+ * For sink devices, this function returns the default color space setting, which is dsDISPLAY_COLORSPACE_RGB.
+ * For source devices, this function is used to get the current color space setting of specified video port.
  *
  * @param[in]  handle       - Handle of the video port returned from dsGetVideoPort()
  * @param[out] color_space  - pointer to color space value. Please refer ::dsDisplayColorSpace_t
@@ -814,7 +816,8 @@ dsError_t dsIsOutputHDR(intptr_t handle, bool* hdr);
 /**
  * @brief Resets Video Output to SDR.
  *
- * This function resets the video output to SDR.
+ * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+ * For source devices, this function resets the video output to SDR.
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success
@@ -924,7 +927,8 @@ dsError_t dsSetBackgroundColor(intptr_t handle, dsVideoBackgroundColor_t color);
 /**
  * @brief Sets/Resets the force HDR mode.
  *
- * This function is used to set/reset force HDR mode for the specified video port.
+ * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+ * For source devices, this function is used to set/reset force HDR mode for the specified video port.
  *
  * @param[in] handle    - Handle of the video port returned from dsGetVideoPort()
  * @param[in] mode      - HDR mode to be forced.  Please refer ::dsHDRStandard_t

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -821,9 +821,9 @@ dsError_t dsIsOutputHDR(intptr_t handle, bool* hdr);
  * @brief Resets Video Output to SDR.
  *
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+ *
  * For source devices, this function resets the video output to SDR.
  * It forces and locks the HDMI output to SDR mode regardless of the source content format
- * It forces and locks the HDMI output to SDR mode regardless of the source content format..
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success

--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -661,7 +661,7 @@ dsError_t dsGetForceDisable4KSupport(intptr_t handle, bool *disable);
 /**
  * @brief Gets the current video Electro-Optical Transfer Function (EOT) value.
  * 
- * This function is used to get the current Electro-Optical Transfer Function of the specified video port.
+ * This function is used to get the current HDR format on a specified video port.
  *
  * @param[in]  handle       - Handle of the video port returned from dsGetVideoPort()
  * @param[out] video_eotf   - EOTF value.  Please refer ::dsHDRStandard_t


### PR DESCRIPTION
**1. What will be expected If we set dsSetForceHDRMode()/dsResetOutputToSDR() while playing the HDR streams and update the interface for the same.**

Both will return OPERATION_NOT_SUPPORTED in Sink

dsSetForceHDRMode - Currently No implementation
dsResetOutputToSDR - Currently returns dsERR_NONE

**2. Please check setforcedisable4ksupport() need to remove form the interface file as it’s not implemented for both sink & source.**

Please refer this link - It is required for Source devices. Currently it must return NOT_SUPPORTED but in future it will be useful for Non UHD cases https://github.com/rdkcentral/rdk-halif-device_settings/pull/16#discussion_r1567595957

**3. In case of Color Capabilities need to check which function used in middle ware keep those API’s only, rest will be removed and what will be default values that also need to update in interface**

Default values for sink:

*color_depth = 10;

*color_space = dsDISPLAY_COLORSPACE_RGB;