### PR TITLE
gh #45 Remove the prerequisite dsCompositeInSelectPort() from dsCompositeInScaleVideo()

### DIFF
--- a/include/dsCompositeIn.h
+++ b/include/dsCompositeIn.h
@@ -225,7 +225,7 @@ dsError_t dsCompositeInSelectPort (dsCompositeInPort_t Port);
  * 
  * @warning  This API is Not thread safe.
  * 
- * @pre  dsCompositeInInit(), dsCompositeInSelectPort() should be called before calling this API.
+ * @pre  dsCompositeInInit() should be called before calling this API.
  */
 
 dsError_t dsCompositeInScaleVideo (int32_t x, int32_t y, int32_t width, int32_t height);


### PR DESCRIPTION
Remove the prerequisite dsCompositeInSelectPort() from dsCompositeInScaleVideo()