### PR TITLE
Feature/issues47 hdmi in interface architectural comments

### DIFF
--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -252,6 +252,7 @@ dsError_t dsHdmiInScaleVideo (int32_t x, int32_t y, int32_t width, int32_t heigh
  * 
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  * For source devices, this function updates the video zoom on the active HDMI input using the provided zoom mode if it has hdmi input support, else returns dsERR_OPERATION_NOT_SUPPORTED.
+ * The HDMI port has to be selected by calling dsHdmiInSelectPort() before setting the zoom mode.
  *
  * @param[in] requestedZoomMode     - HDMI input zoom mode.  Please refer ::dsVideoZoom_t
  *                                          dsVideoZoom_t is within vidoeDeviceTypes.h
@@ -263,7 +264,7 @@ dsError_t dsHdmiInScaleVideo (int32_t x, int32_t y, int32_t width, int32_t heigh
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
  * 
- * @pre dsHdmiInInit() must be called before calling this API.
+ * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 
  * @warning  This API is Not thread safe.
  * 

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -115,6 +115,8 @@ extern "C" {
  * 
  * @warning  This API is Not thread safe.
  * 
+ * @post dsHdmiInTerm must be called to release resources.
+ *
  * @see dsHdmiInTerm()
  * 
  */

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -276,6 +276,7 @@ dsError_t dsHdmiInSelectZoomMode (dsVideoZoom_t requestedZoomMode);
  * 
  * @param[out] resolution              - Current video port resolution.  Please refer ::dsVideoPortResolution_t
  *                                          dsVideoPortResolution_t is currently in the audioVisual combined file.
+ *                                          The 'stereoScopicMode' member in the _dsVideoPortResolution_t structure is unused.
  * 
  * 
  * @return dsError_t                        - Status
@@ -341,6 +342,7 @@ typedef void (*dsHdmiInStatusChangeCB_t)(dsHdmiInStatus_t inputStatus);
  * @param[in] port              - Port in which video mode updated. Please refer ::dsHdmiInPort_t
  * @param[in] videoResolution   - current video resolution of the port.  Please refer ::dsVideoPortResolution_t
  *                                  dsVideoPortResolution_t is currently in the audioVisual combined file.
+ *                                  The 'stereoScopicMode' member in the _dsVideoPortResolution_t structure is unused.
  * 
  * @pre dsHdmiInRegisterVideoModeUpdateCB() must be called before this API
  *


### PR DESCRIPTION
As per architectural discussion , since stereoScopicMode member in _dsVideoPortResolution_t  structure is not used.
Added a comment in GetCurrentVideoMode and dsHdmiInVideoModeUpdateCB_t 