### PR TITLE
gh #53 Info about SEI Signalling in AVIContentTypeChangeCB

### DIFF
--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -544,6 +544,9 @@ dsError_t dsHdmiInRegisterAVLatencyChangeCB (dsAVLatencyChangeCB_t CBFunc);
  * @retval dsERR_GENERAL                    - Underlying undefined platform error
  *
  * @pre dsHdmiInInit() must be called before calling this API
+ *
+ * @note For IP and Tuner Video source, the Picture mode events are updated through SEI info handled from TVSettings module
+ *
  * @see dsHdmiInAviContentTypeChangeCB_t
  * 
  * @warning  This API is Not thread safe.


### PR DESCRIPTION
During TV Setting review, it has been suggested by the architect team to provide a note on how the SEI info is being handled for the Picture mode events in the HAL Interface file (dsHDMIIn).  So the function dsHdmiInRegisterAviContentTypeChangeCB should be updated with a note saying " For IP and Tuner Video source, the Picture mode events are updated through SEI info handled from TVSettings module" 

 

Below is the Architecture team feedback.

"As soon as I see "This applies only to IP video sources and Tuner video sources" I ask the question "then where do I get it for HDMI?". So to avoid having to hunt state it. It make life easier and the interface better."