### PR TITLE
Feature/issues55 Remove dsGetHDMIARCPortID() from dsAudio Interface

### DIFF
--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -1718,29 +1718,6 @@ dsError_t  dsSetSecondaryLanguage(intptr_t handle, const char* sLang);
 dsError_t  dsGetSecondaryLanguage(intptr_t handle, char* sLang);
 
 /**
- * @brief Gets the HDMI ARC port ID for each platform
- *
- * For sink devices, this function will get HDMI ARC port ID of the platform.
- * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
- *
- * @param[in] portId  - HDMI ARC port ID
- *
- * @return dsError_t                      -  Status 
- * @retval dsERR_NONE                     -  Success
- * @retval dsERR_NOT_INITIALIZED          -  Module is not initialised
- * @retval dsERR_INVALID_PARAM            -  Parameter passed to this function is invalid
- * @retval dsERR_OPERATION_NOT_SUPPORTED  -  The attempted operation is not supported
- * @retval dsERR_GENERAL                  -  Underlying undefined platform error
- * 
- * @pre  dsAudioPortInit() should be called before calling this API.
- * 
- * @warning  This API is Not thread safe.
- * 
- * @see dsGetSupportedARCTypes()
- */
-dsError_t dsGetHDMIARCPortId(int *portId);
-
-/**
 * @brief Sets the Mixer Volume level of sink device for the given input
 * This API is specific to sink devices
 *


### PR DESCRIPTION
Getting the HDMI ARC Port ID is handled in DS Generic. It fetches the ARC Port ID from persistence and it is not dependent on HAL