### PR TITLE
Frame Rate Mode and Frame Rate API description update

### DIFF
--- a/include/dsVideoDevice.h
+++ b/include/dsVideoDevice.h
@@ -354,13 +354,13 @@ dsError_t dsSetFRFMode(intptr_t handle, int frfmode);
 dsError_t dsGetFRFMode(intptr_t handle, int *frfmode);
 
 /**
- * @brief Gets the current framerate of the device
+ * @brief Gets the current panel refresh rate of the device
  *
- * For sink devices, this function returns the current framerate of the video device.
+ * For sink devices, this function returns the current panel refresh rate of the device.
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in]  handle       - The handle returned from the dsGetVideoDevice() function
- * @param[out] framerate    - Current frame rate will be represented.
+ * @param[out] framerate    - Current Panel Refresh Rate will be represented.
  *                            Returns the value as a string(eg:"3840x2160px48")
  *
  *
@@ -382,17 +382,17 @@ dsError_t dsGetCurrentDisplayframerate(intptr_t handle, char *framerate);
  
 
 /**
- * @brief Sets the display framerate for the device
+ * @brief Sets the panel refresh rate for the device
  *
- * For sink devices, this function sets the framerate for the video device.
+ * For sink devices, this function sets the panel refresh rate for the device.
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in] handle    - The handle returned from the dsGetVideoDevice() function
- * @param[in] framerate - Framerate value to be set which is platform-specific
- *                        Expects the value as a string(eg:"3840x2160px48")
+ * @param[in] framerate - Panel Refresh Rate value to be set which is platform-specific.
+ *                        Expects the value as a string(eg:"3840x2160px48").
  *                        aaaaxbbbbxyy (aaaaxbbbb - Panel Resolution, yy - Panel Refresh Rate)
  *
- * @return dsError_t                       - Status
+ * @return dsError_t                        - Status
  * @retval dsERR_NONE                       - Success
  * @retval dsERR_NOT_INITIALIZED            - Module is not initialized
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid

--- a/include/dsVideoDevice.h
+++ b/include/dsVideoDevice.h
@@ -307,8 +307,8 @@ dsError_t dsForceDisableHDRSupport(intptr_t handle, bool disable);
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in] handle    - The handle returned from the dsGetVideoDevice() function
- * @param[in] frfmode   - integer with corresponding Framerate value. 
- *                               Please refer ::dsVideoFrameRate_t for max and min framerate.
+ * @param[in] frfmode   - integer value to enable/disable Auto Framerate mode.
+ *                               1 to enable auto framerate mode, 0 to disable auto framerate mode
  *
  * @return dsError_t                       - Status
  * @retval dsERR_NONE                       - Success
@@ -334,8 +334,8 @@ dsError_t dsSetFRFMode(intptr_t handle, int frfmode);
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in]  handle   - The handle returned from the dsGetVideoDevice() function
- * @param[out] frfmode  - integer with corresponding Framerate value of the device. 
- *                             Please refer :: dsVideoFrameRate_t for max and min framerate.
+ * @param[out] frfmode  - integer value corresponding to Auto Framerate mode of the device.
+ *                             1 if auto framerate mode is enabled, 0 if auto framerate mode is disabled
  *
  * @return dsError_t                       - Status
  * @retval dsERR_NONE                       - Success
@@ -360,9 +360,8 @@ dsError_t dsGetFRFMode(intptr_t handle, int *frfmode);
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in]  handle       - The handle returned from the dsGetVideoDevice() function
- * @param[out] framerate    - Current frame rate will be represented in FPS
- *                             Please refer ::dsVideoFrameRate_t for  max and min framerate.
- *                            Updates the value as a string(eg:"60").
+ * @param[out] framerate    - Current frame rate will be represented.
+ *                            Returns the value as a string(eg:"3840x2160px48")
  *
  * @return dsError_t                        - Status
  * @retval dsERR_NONE                       - Success
@@ -388,9 +387,8 @@ dsError_t dsGetCurrentDisplayframerate(intptr_t handle, char *framerate);
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in] handle    - The handle returned from the dsGetVideoDevice() function
- * @param[in] framerate - Framerate value to be set frame will be represented in FPS. 
- *                        Please refer ::dsVideoFrameRate_t for  max and min framerate.
- *                        Expects the value as a string(eg:"60").
+ * @param[in] framerate - Framerate value to be set.
+ *                        Expects the value as a string(eg:"3840x2160px48")
  *
  * @return dsError_t                       - Status
  * @retval dsERR_NONE                       - Success

--- a/include/dsVideoDevice.h
+++ b/include/dsVideoDevice.h
@@ -363,6 +363,7 @@ dsError_t dsGetFRFMode(intptr_t handle, int *frfmode);
  * @param[out] framerate    - Current frame rate will be represented.
  *                            Returns the value as a string(eg:"3840x2160px48")
  *
+ *
  * @return dsError_t                        - Status
  * @retval dsERR_NONE                       - Success
  * @retval dsERR_NOT_INITIALIZED            - Module is not initialized 
@@ -387,8 +388,9 @@ dsError_t dsGetCurrentDisplayframerate(intptr_t handle, char *framerate);
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in] handle    - The handle returned from the dsGetVideoDevice() function
- * @param[in] framerate - Framerate value to be set.
+ * @param[in] framerate - Framerate value to be set which is platform-specific
  *                        Expects the value as a string(eg:"3840x2160px48")
+ *                        aaaaxbbbbxyy (aaaaxbbbb - Panel Resolution, yy - Panel Refresh Rate)
  *
  * @return dsError_t                       - Status
  * @retval dsERR_NONE                       - Success


### PR DESCRIPTION
Update the description below APIs:

dsSetFRFMode()
frame rate mode :   0 for auto framerate mode disabled, 1 for auto framerate mode enabled (must be one of the following: 0, 1)

dsSetDisplayframerate(): 
"3840x2160px60"