### PR TITLE
gh #76 Add new getHdmiVersion API to 2.0.0

### DIFF
--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -762,6 +762,28 @@ dsError_t dsSetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool allmSupport);
  */
 dsError_t dsGetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool *allmSupport);
 
+/**
+* @brief Gets the Maximum HDMI Compatibility Version supported by the given port.
+*
+* For sink devices, this function gets the Maximum HDMI Compatibility Version supported by the given port.
+* For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+*
+* @param[in] iHdmiPort                 - HDMI input port.  Please refer ::dsHdmiInPort_t
+* @param[out] maxCompatibilityVersion  - Maximum Compatibility version supported by the given port. Please refer::dsHdmiMaxCapabilityVersion_t
+*
+* @return dsError_t                        - Status
+* @retval dsERR_NONE                       - Success
+* @retval dsERR_NOT_INITIALIZED            - Module is not initialised
+* @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+* @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+* @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+*
+* @pre dsHdmiInInit() must be called before calling this API
+*
+* @warning  This API is Not thread safe
+*
+*/
+dsError_t dsGetHdmiVersion(dsHdmiInPort_t iHdmiPort, dsHdmiMaxCapabilityVersion_t *maxCompatibilityVersion);
 
 #ifdef __cplusplus
 }

--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -198,6 +198,16 @@ typedef enum dsVideoPlaneType {
     dsVideoPlane_MAX            /*!< Out of bounds*/
 }dsVideoPlaneType_t;
 
+/**
+* @brief Enum for Hdmi Max Compatibility version
+*/
+typedef enum dsHdmiMaxCapabilityVersion{
+    HDMI_COMPATIBILITY_VERSION_14 = 0, /*!< Hdmi Compatibility Version 1.4 */
+    HDMI_COMPATIBILITY_VERSION_20,     /*!< Hdmi Compatibility Version 2.0 */
+    HDMI_COMPATIBILITY_VERSION_21,     /*!< Hdmi Compatibility Version 2.1 */
+    HDMI_COMPATIBILITY_VERSION_MAX     /*!< Out of bounds */
+}dsHdmiMaxCapabilityVersion_t;
+
 #endif // End of __DS_HDMI_IN_TYPES_H__
 
 /** @} */ // End of dsHdmiIn_HAL_Type_H


### PR DESCRIPTION
Adding the new getHdmiVersion API on top of tag version 2.0.0

This is a workaround to resolve the build errors due to deprecated APIs in DeviceSettings