### PR TITLE
Feature/issues83 Mismatch in dialog enhancement range

### DIFF
--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -286,7 +286,7 @@ dsError_t  dsSetAudioCompression(intptr_t handle, int compression);
  * This function returns the dialog enhancement level of the audio port corresponding to the specified port handle.
  *
  * @param[in] handle - Handle for the output audio port
- * @param[out] level - Pointer to Dialog Enhancement level (Value ranges from 0 to 16)
+ * @param[out] level - Pointer to Dialog Enhancement level (Value ranges from 0 to 12)
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success
@@ -309,7 +309,7 @@ dsError_t  dsGetDialogEnhancement(intptr_t handle, int *level);
  * This function sets the dialog enhancement level to be used in the audio port corresponding to specified port handle.
  *
  * @param[in] handle  - Handle for the output audio port.
- * @param[in] level   - Dialog Enhancement level. Level ranges from 0 to 16.
+ * @param[in] level   - Dialog Enhancement level. Level ranges from 0 to 12.
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success

--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -286,7 +286,7 @@ dsError_t  dsSetAudioCompression(intptr_t handle, int compression);
  * This function returns the dialog enhancement level of the audio port corresponding to the specified port handle.
  *
  * @param[in] handle - Handle for the output audio port
- * @param[out] level - Pointer to Dialog Enhancement level (Value ranges from 0 to 12)
+ * @param[out] level - Pointer to Dialog Enhancement level (Value ranges from 0 to 12(as per 2.6 IDK) or 0 to 16(as per 2.4.1 IDK))
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success
@@ -309,7 +309,7 @@ dsError_t  dsGetDialogEnhancement(intptr_t handle, int *level);
  * This function sets the dialog enhancement level to be used in the audio port corresponding to specified port handle.
  *
  * @param[in] handle  - Handle for the output audio port.
- * @param[in] level   - Dialog Enhancement level. Level ranges from 0 to 12.
+ * @param[in] level   - Dialog Enhancement level. Level ranges from 0 to 12(as per 2.6 IDK) or 0 to 16(as per 2.4.1 IDK)
  *
  * @return dsError_t                      -  Status 
  * @retval dsERR_NONE                     -  Success


### PR DESCRIPTION
With latest 2.6 IDK/SDK, the Dialog Enhancement level range is 0 to 12. But interface is still with the range 0 to 16 which is valid for older 2.4.1 IDK , 2.5 SDK version