### PR TITLE
gh #85 HDMI Hal header updation for the maximum number of HDMI ports

### DIFF
--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -108,6 +108,7 @@ typedef enum _dsHdmiInPort_t
     dsHDMI_IN_PORT_0,          /*!< HDMI input port index for PORT 0 */
     dsHDMI_IN_PORT_1,          /*!< HDMI input port index for PORT 1 */
     dsHDMI_IN_PORT_2,          /*!< HDMI input port index for PORT 2 */
+    dsHDMI_IN_PORT_3,          /*!< HDMI input port index for PORT 3 */
     dsHDMI_IN_PORT_MAX         /*!< Out of range */
 } dsHdmiInPort_t;
 

--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -109,6 +109,7 @@ typedef enum _dsHdmiInPort_t
     dsHDMI_IN_PORT_1,          /*!< HDMI input port index for PORT 1 */
     dsHDMI_IN_PORT_2,          /*!< HDMI input port index for PORT 2 */
     dsHDMI_IN_PORT_3,          /*!< HDMI input port index for PORT 3 */
+    dsHDMI_IN_PORT_4,          /*!< HDMI input port index for PORT 4 */
     dsHDMI_IN_PORT_MAX         /*!< Out of range */
 } dsHdmiInPort_t;
 


### PR DESCRIPTION
Currently the maximum number of HDMI ports supported in hal is 3.

typedef enum _dsHdmiInPort_t

{     dsHDMI_IN_PORT_NONE = -1,  /!< HDMI input port index for NONE /          

      dsHDMI_IN_PORT_0,          /!< HDMI input port index for PORT 0 /           

      dsHDMI_IN_PORT_1,          /!< HDMI input port index for PORT 1 /         

      dsHDMI_IN_PORT_2,          /!< HDMI input port index for PORT 2 /         

      dsHDMI_IN_PORT_MAX         /!< Out of range / 

}dsHdmiInPort_t;

To cater the futuristic needs, the number of hdmi ports will be now extended to support upto 5 ports. So the hal header will now support these needs through this enum. 

https://github.com/rdkcentral/rdk-halif-device_settings/blob/4.0.0/include/dsHdmiInTypes.h