### PR TITLE
RDKTV-34986: HDMI Hal header updation for the maximum number of HDMI ports

### DIFF
--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -108,6 +108,8 @@ typedef enum _dsHdmiInPort_t
     dsHDMI_IN_PORT_0,          /*!< HDMI input port index for PORT 0 */
     dsHDMI_IN_PORT_1,          /*!< HDMI input port index for PORT 1 */
     dsHDMI_IN_PORT_2,          /*!< HDMI input port index for PORT 2 */
+    dsHDMI_IN_PORT_3,          /*!< HDMI input port index for PORT 3 */
+    dsHDMI_IN_PORT_4,          /*!< HDMI input port index for PORT 4 */
     dsHDMI_IN_PORT_MAX         /*!< Out of range */
 } dsHdmiInPort_t;
 


### PR DESCRIPTION
Reason for change: Increased dsHDMI_IN_PORT_MAX value to 5.
Test Procedure: As per Jira.
Risks: Low
Priority:  P1
Signed-off-by: Dhivya Ilangovan <dhivya.dilangovan@sky.uk>