### PR TITLE
gh #90 dsHdmiInScaleVideo and dsHdmiInGetCurrentVideoMode test Cases to be Executed After dsHdmiInSelectPort

### DIFF
--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -240,6 +240,7 @@ dsError_t dsHdmiInSelectPort (dsHdmiInPort_t Port, bool audioMix, dsVideoPlaneTy
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid. 
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ *                                              e.g: the @pre condition other than initialization is not met
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 
@@ -289,6 +290,7 @@ dsError_t dsHdmiInSelectZoomMode (dsVideoZoom_t requestedZoomMode);
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ *                                              e.g: the @pre condition other than initialization is not met
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -265,6 +265,7 @@ dsError_t dsHdmiInScaleVideo (int32_t x, int32_t y, int32_t width, int32_t heigh
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ *                                              e.g: the @pre condition other than initialization is not met
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -241,7 +241,7 @@ dsError_t dsHdmiInSelectPort (dsHdmiInPort_t Port, bool audioMix, dsVideoPlaneTy
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
  * 
- * @pre dsHdmiInInit() must be called before calling this API.
+ * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 
  * @warning  This API is Not thread safe.
  * 
@@ -290,7 +290,7 @@ dsError_t dsHdmiInSelectZoomMode (dsVideoZoom_t requestedZoomMode);
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
  * 
- * @pre dsHdmiInInit() must be called before calling this API.
+ * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 
  * @warning  This API is Not thread safe.
  * 

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -240,6 +240,7 @@ dsError_t dsHdmiInSelectPort (dsHdmiInPort_t Port, bool audioMix, dsVideoPlaneTy
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid. 
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ * @retval dsERR_GENERAL                    - Underlying undefined platform error
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 
@@ -289,6 +290,7 @@ dsError_t dsHdmiInSelectZoomMode (dsVideoZoom_t requestedZoomMode);
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+ * @retval dsERR_GENERAL                    - Underlying undefined platform error
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -240,7 +240,6 @@ dsError_t dsHdmiInSelectPort (dsHdmiInPort_t Port, bool audioMix, dsVideoPlaneTy
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid. 
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
- * @retval dsERR_GENERAL                    - Underlying undefined platform error
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 
@@ -290,7 +289,6 @@ dsError_t dsHdmiInSelectZoomMode (dsVideoZoom_t requestedZoomMode);
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
  * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
- * @retval dsERR_GENERAL                    - Underlying undefined platform error
  * 
  * @pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.
  * 


### PR DESCRIPTION
Problem/Opportunity
Need to update the @pre field of the APIs - dsHdmiInScaleVideo and dsHdmiInGetCurrentVideoMode with the below information.
@pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API.

Steps to reproduce
Not applicable

Expected Behavior
@pre dsHdmiInInit() and dsHdmiInSelectPort() must be called before calling this API should be updated for mentioned APis

Actual Behavior
Currently, it s not updated properly

Notes (Optional)
Not applicable.

TestSuit PR - https://github.com/rdkcentral/rdk-halif-test-device_settings/pull/293