### PR TITLE
dsCompositeIn: Missing Preconditions in the Specification

### DIFF
--- a/include/dsCompositeIn.h
+++ b/include/dsCompositeIn.h
@@ -228,7 +228,7 @@ dsError_t dsCompositeInSelectPort (dsCompositeInPort_t Port);
  * 
  * @warning  This API is Not thread safe.
  * 
- * @pre  dsCompositeInInit() should be called before calling this API.
+ * @pre  dsCompositeInInit() and dsCompositeInSelectPort() should be called before calling this API.
  */
 
 dsError_t dsCompositeInScaleVideo (int32_t x, int32_t y, int32_t width, int32_t height);


### PR DESCRIPTION
We need to specifically define the pre requirements in the @pre section of the document.

As most of the L1 and L2 are getting generated with ChatGPT tools, we need to make sure that every aspect is captured correctly in the Interface file. The below functions doesn’t have the Select port as a pre-requirement

dsCompositeInScaleVideo