### PR TITLE
gh #103 Add all the MS12 features to dsMS12Capabilities_t enum

### DIFF
--- a/include/dsAVDTypes.h
+++ b/include/dsAVDTypes.h
@@ -339,7 +339,7 @@ typedef enum _dsMS12Capabilities_t {
     dsMS12SUPPORT_MISteering       = 0x100,     ///< MS12 MI Steering
     dsMS12SUPPORT_GraphicEqualizer = 0x200,     ///< MS12 Graphic equalizer
     dsMS12SUPPORT_LEConfig         = 0x400,     ///< MS12 LE config
-    dsMS12SUPPORT_Invalid = 0x80               ///< Invalid / Out of range
+    dsMS12SUPPORT_Invalid = 0x800               ///< Invalid / Out of range
 } dsMS12Capabilities_t;
 
 /**

--- a/include/dsAVDTypes.h
+++ b/include/dsAVDTypes.h
@@ -331,6 +331,14 @@ typedef enum _dsMS12Capabilities_t {
     dsMS12SUPPORT_DolbyVolume = 0x01,           ///< MS12 supported Dolby Volume
     dsMS12SUPPORT_InteligentEqualizer = 0x02,   ///< MS12 supported Intelligent Equalizer
     dsMS12SUPPORT_DialogueEnhancer = 0x04,      ///< MS12 Dialogue Enhancer supported
+    dsMS12SUPPORT_Volumeleveller   = 0x08,      ///< MS12 Volume leveller
+    dsMS12SUPPORT_BassEnhancer     = 0x10,      ///< MS12 Bass Enhancer
+    dsMS12SUPPORT_SurroundDecoder  = 0x20,      ///< MS12 Surround Decoder
+    dsMS12SUPPORT_DRCMode          = 0x40,      ///< MS12 DRC Mode
+    dsMS12SUPPORT_SurroundVirtualizer = 0x80,   ///< MS12 Surround Virtualizer
+    dsMS12SUPPORT_MISteering       = 0x100,     ///< MS12 MI Steering
+    dsMS12SUPPORT_GraphicEqualizer = 0x200,     ///< MS12 Graphic equalizer
+    dsMS12SUPPORT_LEConfig         = 0x400,     ///< MS12 LE config
     dsMS12SUPPORT_Invalid = 0x80               ///< Invalid / Out of range
 } dsMS12Capabilities_t;
 

--- a/include/dsAVDTypes.h
+++ b/include/dsAVDTypes.h
@@ -327,19 +327,19 @@ typedef struct _dsAudioARCStatus_t {
  * of the standards.
  */
 typedef enum _dsMS12Capabilities_t {
-    dsMS12SUPPORT_NONE = 0x0,                   ///< MS12 Supported None
-    dsMS12SUPPORT_DolbyVolume = 0x01,           ///< MS12 supported Dolby Volume
-    dsMS12SUPPORT_InteligentEqualizer = 0x02,   ///< MS12 supported Intelligent Equalizer
-    dsMS12SUPPORT_DialogueEnhancer = 0x04,      ///< MS12 Dialogue Enhancer supported
-    dsMS12SUPPORT_Volumeleveller   = 0x08,      ///< MS12 Volume leveller
-    dsMS12SUPPORT_BassEnhancer     = 0x10,      ///< MS12 Bass Enhancer
-    dsMS12SUPPORT_SurroundDecoder  = 0x20,      ///< MS12 Surround Decoder
-    dsMS12SUPPORT_DRCMode          = 0x40,      ///< MS12 DRC Mode
-    dsMS12SUPPORT_SurroundVirtualizer = 0x80,   ///< MS12 Surround Virtualizer
-    dsMS12SUPPORT_MISteering       = 0x100,     ///< MS12 MI Steering
-    dsMS12SUPPORT_GraphicEqualizer = 0x200,     ///< MS12 Graphic equalizer
-    dsMS12SUPPORT_LEConfig         = 0x400,     ///< MS12 LE config
-    dsMS12SUPPORT_Invalid = 0x800               ///< Invalid / Out of range
+    dsMS12SUPPORT_NONE = 0x0,                        ///< MS12 Supported None
+    dsMS12SUPPORT_DolbyVolume = (1 << 0),            ///< MS12 supported Dolby Volume
+    dsMS12SUPPORT_InteligentEqualizer = (1 << 1),    ///< MS12 supported Intelligent Equalizer
+    dsMS12SUPPORT_DialogueEnhancer = (1 << 2),       ///< MS12 Dialogue Enhancer supported
+    dsMS12SUPPORT_Volumeleveller   = (1 << 3),       ///< MS12 Volume leveller
+    dsMS12SUPPORT_BassEnhancer     = (1 << 4),       ///< MS12 Bass Enhancer
+    dsMS12SUPPORT_SurroundDecoder  = (1 << 5),       ///< MS12 Surround Decoder
+    dsMS12SUPPORT_DRCMode          = (1 << 6),       ///< MS12 DRC Mode
+    dsMS12SUPPORT_SurroundVirtualizer = (1 << 7),    ///< MS12 Surround Virtualizer
+    dsMS12SUPPORT_MISteering       = (1 << 8),       ///< MS12 MI Steering
+    dsMS12SUPPORT_GraphicEqualizer = (1 << 9),       ///< MS12 Graphic equalizer
+    dsMS12SUPPORT_LEConfig         = (1 << 10),      ///< MS12 LE config
+    dsMS12SUPPORT_Invalid = (1 << 31)                ///< Invalid / Out of range
 } dsMS12Capabilities_t;
 
 /**


### PR DESCRIPTION
dsMS12Capabilities_t enum misses out some of the MS12 Capabilities.

All the MS12 Capabilities has to be added to the dsMS12Capabilities_t enum, so that dsGetMS12Capabilities() can return the OR-ed value of the supported MS12 capabilities