### PR TITLE
gh #117 Feature: Variable Refresh Rate APIs

### DIFF
--- a/docs/pages/ds-hdmi-in_halSpec.md
+++ b/docs/pages/ds-hdmi-in_halSpec.md
@@ -42,6 +42,7 @@
 - `SPD`    - Source Product Description.
 - `HdmiIn` - HDMI Input
 - `ALLM`   - Auto Low Latency Mode
+- `VRR`    - Variable Refresh Rate
 
 ## Description
 

--- a/docs/pages/ds-hdmi-in_halSpec.md
+++ b/docs/pages/ds-hdmi-in_halSpec.md
@@ -96,6 +96,7 @@ This interface must support asynchronous notifications operations:
 - `dsHdmiInRegisterAllmChangeCB()` must facilitate asynchronous status notifications using the callback `dsHdmiInAllmChangeCB_t`.
 - `dsHdmiInRegisterAVLatencyChangeCB()` must facilitate asynchronous notifications using the callback `dsAVLatencyChangeCB_t` when the AV latency changes.
 - `dsHdmiInRegisterAviContentTypeChangeCB()` must facilitate asynchronous notifications using the call back `dsHdmiInAviContentTypeChangeCB_t` when HDMI input content type changes.
+- `dsHdmiInRegisterVRRChangeCB` must facilitate asynchronous notifications using the call back `dsHdmiInVRRChangeCB_t` when HDMI input VRR signalling status changes.
 
  This interface is allowed to establish its own thread context for its operation, ensuring minimal impact on system resources. Additionally, this interface is responsible for releasing the resources it creates for its operation once the respective operation concludes.
 
@@ -160,9 +161,9 @@ The `caller` is expected to have complete control over the life cycle of the `HA
 
 1. Initialize the `HAL` `dsHdmiInInit()` before making any other `APIs` calls.  If `dsHdmiInInit()` call fails, the `HAL` must return the respective error code, so that the `caller` can retry the operation.
 
-2. The `caller` can call `dsHdmiInSelectPort()`, `dsHdmiInScaleVideo()`, `dsSetEdidVersion()` and `dsHdmiInSelectZoomMode()` to set the needed information.
+2. The `caller` can call `dsHdmiInSelectPort()`, `dsHdmiInScaleVideo()`, `dsSetEdidVersion()` and `dsHdmiInSelectZoomMode()`, `dsHdmiInSetVRRSupport()` to set the needed information.
 
-3. The `caller` can call `dsHdmiInGetNumberOfInputs()`, `dsHdmiInGetStatus()`, `dsGetEDIDBytesInfo()`, `dsIsHdmiARCPort()`, `dsGetHDMISPDInfo()`,  `dsGetEdidVersion()`, `dsGetAllmStatus()`, `dsGetSupportedGameFeaturesList()`, `dsGetAVLatency()` and `dsHdmiInGetCurrentVideoMode()` to query the needed information.
+3. The `caller` can call `dsHdmiInGetNumberOfInputs()`, `dsHdmiInGetStatus()`, `dsGetEDIDBytesInfo()`, `dsIsHdmiARCPort()`, `dsGetHDMISPDInfo()`,  `dsGetEdidVersion()`, `dsGetAllmStatus()`, `dsGetSupportedGameFeaturesList()`, `dsGetAVLatency()`, `dsHdmiInGetCurrentVideoMode()`, `dsHdmiInGetVRRSupport()` and  `dsHdmiInGetVRRStatus()` to query the needed information.
 
 4. Callbacks can be set with:
     - `dsHdmiInRegisterConnectCB()` - used when the HDMIin port connection status changes
@@ -172,6 +173,7 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     - `dsHdmiInRegisterAllmChangeCB()` - used when the HDMI input ALLM mode changes
     - `dsHdmiInRegisterAVLatencyChangeCB()` - used when the AV latency changes
     - `dsHdmiInRegisterAviContentTypeChangeCB()` - used when the Avi Content type changes
+    - `dsHdmiInRegisterVRRChangeCB` - used when the HDMI input VRR signalling status change
 
 5. De-initialize the `HAL` using `dsHdmiInTerm()`
 
@@ -258,6 +260,21 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL->>Driver:Getting the AV latency
     Driver-->>HAL:return
     HAL-->>Caller:return
+    Caller->>HAL:dsHdmiInGetVRRSupport()
+    Note over HAL: Gets the VRR support(enabled/disabled)
+    HAL->>Driver:Getting the VRR support
+    Driver-->>HAL:return
+    HAL-->>Caller:return
+    Caller->>HAL:dsHdmiInSetVRRSupport()
+    Note over HAL: Sets the VRR support(enable/disable)
+    HAL->>Driver:Setting the VRR support
+    Driver-->>HAL:return
+    HAL-->>Caller:return
+    Caller->>HAL:dsHdmiInGetVRRStatus()
+    Note over HAL: Gets the current VRR signalling type
+    HAL->>Driver:Getting the VRR type
+    Driver-->>HAL:return
+    HAL-->>Caller:return
     Caller->>HAL:dsHdmiInRegisterConnectCB()
     Note over HAL: Creates the callback for when the HDMI connection status changes.
     HAL-->>Caller:return
@@ -278,6 +295,9 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL-->>Caller:return
     Caller->>HAL:dsHdmiInRegisterAviContentTypeChangeCB()
     Note over HAL: Creates the callback for when the Avi Content type changes.
+    HAL-->>Caller:return
+    Caller->>HAL:dsHdmiInRegisterVRRChangeCB()
+    Note over HAL: Creates the callback for when the HDMI input VRR signalling status changes.
     HAL-->>Caller:return
     Note over HAL: HDMI Input connection status changed
     Driver-->>HAL:return
@@ -300,6 +320,9 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     Note over HAL: Avi content type changed
     Driver-->>HAL:return
     HAL-->>Caller:dsHdmiInAviContentTypeChangeCB_t callback returned
+    Note over HAL: VRR signal staus changed
+    Driver-->>HAL:return
+    HAL-->>Caller:dsHdmiInVRRChangeCB_t callback returned
     Caller ->>HAL:dsHdmiInTerm()
     Note over HAL: Terminates the underlying sub-systems
     HAL->>Driver:Terminates the underlying sub-systems

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -858,7 +858,7 @@ dsError_t dsHdmiInSetVRRSupport(dsHdmiInPort_t port, bool vrrSupport);
 * @param[in] port     - HDMI input port number in which VRR mode changed. Please refer ::dsHdmiInPort_t
 * @param[in] vrrType  - Current VRR type to be notified to the application. Please refer ::dsVRRType_t
 *
-* @pre dsHdmiInRegisterVRRChangeCB() must be called before this API
+* @see dsHdmiInRegisterVRRChangeCB()
 *
 */
 typedef void (*dsHdmiInVRRChangeCB_t)(dsHdmiInPort_t port, dsVRRType_t vrrType);

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -830,6 +830,7 @@ dsError_t dsHdmiInGetVRRSupport(dsHdmiInPort_t port, bool * vrrSupport);
 * This enables the support for HDMI VRR/AMD FreeSync/AMD FreeSync Premium/AMD FreeSync Premium Pro.
 *
 * For sink devices, this function sets the VRR support(enable/disable) for the given port.
+* For a HDMI input port that does not support VRR in HDMI v2.1 mode, this function returns dsERR_OPERATION_NOT_SUPPORTED.
 * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
 *
 * @param[in] port        - HDMI input port. Please refer ::dsHdmiInPort_t

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -710,8 +710,8 @@ dsError_t dsGetAllmStatus (dsHdmiInPort_t iHdmiPort, bool *allmStatus);
  * For sink devices, this function gets all the supported game features list information.
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
- * @param[out] features         - List of all supported game features. 
- *                                       Please refer ::dsSupportedGameFeatureList_t
+ * @param[out] features         - List of all supported game features - "allm","vrr_hdmi","vrr_amd_freesync","vrr_amd_freesync_premium",
+ *                                "vrr_amd_freesync_premium_pro". Please refer ::dsSupportedGameFeatureList_t
  *
  * @return dsError_t                        - Status
  * @retval dsERR_NONE                       - Success
@@ -796,6 +796,116 @@ dsError_t dsSetEdid2AllmSupport (dsHdmiInPort_t iHdmiPort, bool allmSupport);
 *
 */
 dsError_t dsGetHdmiVersion(dsHdmiInPort_t iHdmiPort, dsHdmiMaxCapabilityVersion_t *maxCompatibilityVersion);
+
+/**
+* @brief Gets the VRR support used for a given HDMI input port.
+* This includes support for HDMI VRR, AMD FreeSync, AMD FreeSync Premium, and AMD FreeSync Premium Pro.
+*
+* The default setting is `true` for HDMI ports that are VRR capable, otherwise `false`.
+*
+* For sink devices, this function returns whether the VRR support is enabled/disabled for the given port.
+* It will return the either the default settings of the port or return the value set successfully by dsHdmiInSetVRRSupport.
+* For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+*
+* @param[in] port         - HDMI input port. Please refer ::dsHdmiInPort_t
+* @param[out] vrrSupport  - Flag to hold whether the VRR support is enabled/disabled for that port
+*                            ( @a true if enabled, @a false if disabled)
+*
+* @return dsError_t                        - Status
+* @retval dsERR_NONE                       - Success
+* @retval dsERR_NOT_INITIALIZED            - Module is not initialized
+* @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+* @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+*
+* @pre dsHdmiInInit() must be called before calling this API
+*
+* @warning This API is Not thread safe
+*
+* @see dsHdmiInSetVRRSupport()
+*/
+dsError_t dsHdmiInGetVRRSupport(dsHdmiInPort_t port, bool * vrrSupport);
+
+/**
+* @brief Sets the VRR support for the given HDMI input port when operating in HDMI v2.1 mode.
+* This enables the support for HDMI VRR/AMD FreeSync/AMD FreeSync Premium/AMD FreeSync Premium Pro.
+*
+* For sink devices, this function sets the VRR support(enable/disable) for the given port.
+* For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+*
+* @param[in] port        - HDMI input port. Please refer ::dsHdmiInPort_t
+* @param[in] vrrSupport  - Flag to set the VRR support
+*                           ( @a true to enable, @a false to disable)
+*
+* @return dsError_t                        - Status
+* @retval dsERR_NONE                       - Success
+* @retval dsERR_NOT_INITIALIZED            - Module is not initialised
+* @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+* @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices/sink devices when edid version is 1.4
+* @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
+*
+* @pre dsHdmiInInit() must be called before calling this API
+*
+* @warning This API is Not thread safe
+*
+* @see dsHdmiInGetVRRSupport()
+*/
+dsError_t dsHdmiInSetVRRSupport(dsHdmiInPort_t port, bool vrrSupport);
+
+/**
+* @brief Notifies applications when the HDMI input VRR signalling status changes for the active port.
+*
+* @param[in] port     - HDMI input port number in which VRR mode changed. Please refer ::dsHdmiInPort_t
+* @param[in] vrrType  - Current VRR type to be notified to the application. Please refer ::dsVRRType_t
+*
+* @pre dsHdmiInRegisterVRRChangeCB() must be called before this API
+*
+*/
+typedef void (*dsHdmiInVRRChangeCB_t)(dsHdmiInPort_t port, dsVRRType_t vrrType);
+
+/**
+* @brief Registers a callback for the HDMI input VRR signalling status change event
+*
+* For sink devices, this function registers a callback for the HDMI input VRR signalling status change event.
+* For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+*
+* @param[in] cb -  HDMI input VRR status change callback function. Please refer ::dsHdmiInVRRChangeCB_t
+*
+* @return dsError_t                        - Status
+* @retval dsERR_NONE                       - Success
+* @retval dsERR_NOT_INITIALIZED            - Module is not initialized
+* @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+* @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+*
+* @pre dsHdmiInInit() must be called before calling this API
+* @see dsHdmiInVRRChangeCB_t
+*
+* @warning This API is Not thread safe.
+*
+*/
+dsError_t dsHdmiInRegisterVRRChangeCB(dsHdmiInVRRChangeCB_t cb);
+
+/**
+* @brief Gets the current VRR signalling type for the specified HDMI input port.
+* This includes the current signalling type like HDMI VRR/AMD FreeSync/AMD FreeSync Premium/AMD FreeSync Premium Pro.
+*
+* For sink devices, this function gets current VRR signalling type for the specified HDMI input port.
+* For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
+*
+* @param[in] port      - HDMI input port. Please refer ::dsHdmiInPort_t
+* @param[out] vrrType  - The current VRR type. Please refer ::dsVRRType_t
+*
+* @return dsError_t                        - Status
+* @retval dsERR_NONE                       - Success
+* @retval dsERR_NOT_INITIALIZED            - Module is not initialized
+* @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
+* @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+*
+* @pre dsHdmiInInit() must be called before calling this API
+*
+* @warning This API is Not thread safe
+*
+*/
+dsError_t dsHdmiInGetVRRStatus(dsHdmiInPort_t port, dsVRRType_t *vrrType);
 
 #ifdef __cplusplus
 }

--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -152,7 +152,8 @@ typedef struct _dsHdmiInCap_t
  * @brief Structure that captures Supported Game Features list
  */
 typedef struct _dsSupportedGameFeatureList_t {
-    char gameFeatureList[MAX_FEATURE_LIST_BUFFER_LEN]; /*!< buffer containing the list of comma separated supported game features (e.g: "allm") */
+    char gameFeatureList[MAX_FEATURE_LIST_BUFFER_LEN]; /*!< buffer containing the list of comma separated supported game features (e.g: "allm","vrr_hdmi",
+							 "vrr_amd_freesync","vrr_amd_freesync_premium") */
     int gameFeatureCount;                              /*!< Total number of supported game features */
 } dsSupportedGameFeatureList_t;
 

--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -204,9 +204,9 @@ typedef enum dsHdmiMaxCapabilityVersion{
 typedef enum dsVRRType {
     dsVRR_NONE,                    // No VRR support
     dsVRR_HDMI_VRR,                // VRR (HDMI v2.1 flavour)
-    dsVRR_AMD_FREESYNC,            // AMD FreeSync
-    dsVRR_AMD_FREESYNC_PREMIUM,    // AMD FreeSync Premium
-    dsVRR_AMD_FREESYNC_PREMIUM_PRO // AMD FreeSync Premium Pro
+    dsVRR_AMD_FREESYNC,            // AMD FreeSync - Basic VRR (Variable Refresh Rate) – prevents tearing and stutter
+    dsVRR_AMD_FREESYNC_PREMIUM,    // AMD FreeSync Premium - Adds Low Framerate Compensation (LFC) and requires at least 120Hz at 1080p+
+    dsVRR_AMD_FREESYNC_PREMIUM_PRO // AMD FreeSync Premium Pro - Includes everything above + HDR support and lower latency with HDR content
 } dsVRRType_t;
 
 #endif // End of __DS_HDMI_IN_TYPES_H__

--- a/include/dsHdmiInTypes.h
+++ b/include/dsHdmiInTypes.h
@@ -198,6 +198,17 @@ typedef enum dsHdmiMaxCapabilityVersion{
     HDMI_COMPATIBILITY_VERSION_MAX     /*!< Out of bounds */
 }dsHdmiMaxCapabilityVersion_t;
 
+/**
+* @brief Enum for Variable Refresh Rate Types
+*/
+typedef enum dsVRRType {
+    dsVRR_NONE,                    // No VRR support
+    dsVRR_HDMI_VRR,                // VRR (HDMI v2.1 flavour)
+    dsVRR_AMD_FREESYNC,            // AMD FreeSync
+    dsVRR_AMD_FREESYNC_PREMIUM,    // AMD FreeSync Premium
+    dsVRR_AMD_FREESYNC_PREMIUM_PRO // AMD FreeSync Premium Pro
+} dsVRRType_t;
+
 #endif // End of __DS_HDMI_IN_TYPES_H__
 
 /** @} */ // End of dsHdmiIn_HAL_Type_H


### PR DESCRIPTION
Following Apis new Apis need to be added to the dsHdmiIn for having the VRR support

dsError_t dsHdmiInGetVRRSupport(dsHdmiInPort_t port, bool * vrrSupport);
dsError_t dsHdmiInSetVRRSupport(dsHdmiInPort_t port, bool vrrSupport);
dsError_t dsHdmiInRegisterVRRChangeCB(dsHdmiInPort_t port, dsHdmiInVRRChangeCB_t cb);
dsError_t dsHdmiInGetVRRStatus(dsHdmiInPort_t port, dsVRRType_t *vrrType);
