### PR TITLE
issue127 correct mermaidcode spaceissue

### DIFF
--- a/docs/pages/ds-audio_halSpec.md
+++ b/docs/pages/ds-audio_halSpec.md
@@ -60,7 +60,7 @@ x[DEVICE SETTINGS AUDIO HAL]<-->z[Audio SoC Driver];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 This interface provides a set of `APIs` to facilitate communication to the Audio `SoC` Driver.
 
@@ -267,4 +267,4 @@ NOTE: The module would operate deterministically if the above call sequence is f
     HAL ->> Driver:dsAudioTerm()
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```

--- a/docs/pages/ds-composite-in_halSpec.md
+++ b/docs/pages/ds-composite-in_halSpec.md
@@ -48,7 +48,7 @@ x[Device Settings CompositeIn HAL]<-->z[SOC Drivers];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 DS `CompositeIn` `HAL` provides a set of `APIs` to initialize, query and set information about the Composite input ports such as getting the number of input ports, getting the current status of a selected input port, setting the video scale, selecting which Composite input to be selected as active and registering callbacks for asynchronous notifications.
 
@@ -227,4 +227,4 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL->>Driver:Terminates the underlying sub-systems
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```

--- a/docs/pages/ds-display_halSpec.md
+++ b/docs/pages/ds-display_halSpec.md
@@ -53,7 +53,7 @@ x[DS Display HAL]<-->z[SOC Drivers];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 `DS` Display `HAL` provides a set of `APIs` to manage operations related to display devices connected to `HDMI` Output port of the source devices.
 
@@ -190,4 +190,4 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL->>Driver:Deallocates the associated data structures & releases display specific handles
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```

--- a/docs/pages/ds-front-panel-display_halSpec.md
+++ b/docs/pages/ds-front-panel-display_halSpec.md
@@ -49,7 +49,7 @@ x[DEVICE SETTINGS FRONT PANEL DISPLAY HAL]<-->z[Front Panel SoC Driver];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 This interface provides a set of `APIs` to facilitate communication to Front Panel `LED` Display `SoC` Drivers.
 
@@ -197,5 +197,4 @@ The various `DS` `FP` `LED` states are as follows:
     HAL ->> Driver: Releases all the resources allocated during FPD init
     Driver-->>HAL:return
     HAL-->>Caller:return
-
- ```
+```

--- a/docs/pages/ds-hdmi-in_halSpec.md
+++ b/docs/pages/ds-hdmi-in_halSpec.md
@@ -56,7 +56,7 @@ x[Device Settings HdmiIn HAL]<-->z[SOC Drivers];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 DS `HdmiIn` `HAL` provides a set of `APIs` to initialize, query and set information about the HDMI input ports such as getting the number of input ports, getting the current status of a selected input port, setting the video scale, selecting which HDMI input to be selected as active and registering callbacks for asynchronous notifications.
 
@@ -329,7 +329,7 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL->>Driver:Terminates the underlying sub-systems
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```
 
 #### Flow Diagram
 

--- a/docs/pages/ds-host_halSpec.md
+++ b/docs/pages/ds-host_halSpec.md
@@ -50,7 +50,7 @@ x[Device Settings HOST HAL]<-->z[SOC Drivers];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 `Device Settings Host` `HAL` provides a set of `APIs` to initialize, query information about the `SoC`.
 
@@ -185,4 +185,4 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL->>Driver:Terminating SoC Power Manager
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```

--- a/docs/pages/ds-video-device_halSpec.md
+++ b/docs/pages/ds-video-device_halSpec.md
@@ -50,7 +50,7 @@ x[Device Settings VIDEO DEVICE HAL]<-->z[SOC Drivers];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 `Device Settings Video Device` `HAL` provides a set of `APIs` to initialize, query information about the `SoC`.
 
@@ -203,4 +203,4 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL ->> Driver: Releases all the resources allocated during dsVideoDeviceInit()
     Driver-->>HAL:return
     HAL-->>Caller:return
-``````
+```

--- a/docs/pages/ds-video-port_halSpec.md
+++ b/docs/pages/ds-video-port_halSpec.md
@@ -53,7 +53,7 @@ x[Device Settings Video Port HAL]<-->z[SOC Drivers];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 `DS` Video Port `HAL` provides a set of `APIs` to initialize, query and set information about the Video ports like getting  video port handle, fetching connected display information such as color depth, color space, matrix coefficients, quantization range, supported video resolutions using the video port handle. It also provides `APIs` to enable or disable content protection like `HDCP` and `DTCP`, to set the background color and preferred color depth of the video port.
 
@@ -260,4 +260,4 @@ The `caller` is expected to have complete control over the life cycle of the `HA
     HAL->>Driver:Terminates the underlying Video Port sub-system
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```


### PR DESCRIPTION
In file docs/pages/ds-host_halSpec.md the mermaid diagrams, end with an additional white space in their last line.
In the sections 'Description' and 'Diagrams' sections, there are mermaid formatted diagrams present. Instead of ```, they end with ``` . While this additional white space is not causing issues in GitHub, this is causing issues in some other markdown parsers like mkdocs

Removing the white space at the end of the diagram ( before the last ``` ) makes the diagrams render properly