### PR TITLE
gh #150 Update handle to intptr_t

### DIFF
--- a/include/dsDisplay.h
+++ b/include/dsDisplay.h
@@ -121,7 +121,7 @@ typedef enum _dsDisplayEvent_t {
  *
  * @pre dsRegisterDisplayEventCallback()
  */
-typedef void (*dsDisplayEventCallback_t)(int handle, dsDisplayEvent_t event,
+typedef void (*dsDisplayEventCallback_t)(intptr_t handle, dsDisplayEvent_t event,
                                              void* eventData/*Optional*/);
 
 /**


### PR DESCRIPTION
Currently we have
typedef void (dsDisplayEventCallback_t)(int handle, dsDisplayEvent_t event,
void eventData/Optional/);

intstead of int handle it should be intptr_t handle. This disconnect is causing a compilation error when using a stricter compiler.