### PR TITLE
Mark resetOutputToSDR as deprecated

### DIFF
--- a/include/dsVideoPort.h
+++ b/include/dsVideoPort.h
@@ -824,6 +824,8 @@ dsError_t dsIsOutputHDR(intptr_t handle, bool* hdr);
 /**
  * @brief Resets Video Output to SDR.
  *
+ * THIS API IS DEPRECATED.
+ *
  * For sink devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * For source devices, this function resets the video output to SDR.


### PR DESCRIPTION
This API is not used, so marking as deprecated and can be removed in future. 