### PR TITLE
gh#164 Update description of APIs from HDMI and Composite

### DIFF
--- a/include/dsCompositeIn.h
+++ b/include/dsCompositeIn.h
@@ -179,6 +179,9 @@ dsError_t dsCompositeInGetNumberOfInputs (uint8_t *pNumberOfInputs);
  * @retval dsERR_GENERAL                  - Underlying undefined platform error
  * 
  * @warning  This API is Not thread safe.
+ *           After any operation that may change ::dsHdmiInStatus_t, dsHdmiInGetStatus()
+ *           may return stale values until ::dsHdmiInStatusChangeCB_t is received.
+ *           After the callback is received, dsHdmiInGetStatus() will return the updated status.
  * 
  * @pre  dsCompositeInInit() should be called before calling this API.
  */
@@ -202,7 +205,9 @@ dsError_t dsCompositeInGetStatus (dsCompositeInStatus_t *pStatus);
  * 
  * @note When a port is selected that port should be set as activePort in ::dsCompositeInStatus_t.
  *              Also, if there is a signal (ie isPortConnected[that port ID] is true), once active, isPresented should be set to true as well.
- * 
+ *       Changes to ::dsCompositeInStatus_t are communicated asynchronously via the
+ *       ::dsCompositeInStatusChangeCB_t callback.
+ *
  * @pre  dsCompositeInInit() should be called before calling this API.
  */
 dsError_t dsCompositeInSelectPort (dsCompositeInPort_t Port);

--- a/include/dsCompositeIn.h
+++ b/include/dsCompositeIn.h
@@ -179,9 +179,9 @@ dsError_t dsCompositeInGetNumberOfInputs (uint8_t *pNumberOfInputs);
  * @retval dsERR_GENERAL                  - Underlying undefined platform error
  * 
  * @warning  This API is Not thread safe.
- *           After any operation that may change ::dsHdmiInStatus_t, dsHdmiInGetStatus()
- *           may return stale values until ::dsHdmiInStatusChangeCB_t is received.
- *           After the callback is received, dsHdmiInGetStatus() will return the updated status.
+ *           After any operation that may change ::dsCompositeInStatus_t, dsCompositeInGetStatus()
+ *           may return stale values until ::dsCompositeInStatusChangeCB_t is received.
+ *           After the callback is received, dsCompositeInGetStatus() will return the updated status.
  * 
  * @pre  dsCompositeInInit() should be called before calling this API.
  */

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -183,6 +183,9 @@ dsError_t dsHdmiInGetNumberOfInputs (uint8_t *pNumberOfinputs);
  * @pre dsHdmiInInit() must be called before calling this API.
  * 
  * @warning  This API is Not thread safe.
+ *           After any operation that may change ::dsHdmiInStatus_t, dsHdmiInGetStatus()
+ *           may return stale values until ::dsHdmiInStatusChangeCB_t is received.
+ *           After the callback is received, dsHdmiInGetStatus() will return the updated status.
  * 
  */
 dsError_t dsHdmiInGetStatus (dsHdmiInStatus_t *pStatus); 
@@ -213,7 +216,9 @@ dsError_t dsHdmiInGetStatus (dsHdmiInStatus_t *pStatus);
  * @pre dsHdmiInInit() must be called before calling this API.
  * 
  * @note When a port is selected, activePort should be set to true in  Please refer ::dsHdmiInStatus_t for that port
- *              Also, if thT port has an active connection, it should update isPresented to true as well.
+ *              Also, if the port has an active connection, it should update isPresented to true as well.
+ *       Changes to ::dsHdmiInStatus_t are communicated asynchronously via the
+ *       ::dsHdmiInStatusChangeCB_t callback.
  * 
  * @warning  This API is Not thread safe.
  * 


### PR DESCRIPTION
Need to update the description of APIs from HDMI( dsHdmiInGetStatus and dsHdmiInSelectPort) and Composite(dsCompositeInGetStatus and dsCompositeInSelectPort) to explain below points
activePort and isPresented will be updated asynchronously in a separate thread, and will be communicated through the (hdmiInStatusChangeCB/dsCompositeInStatusChangeCB) callback.
Fixes #164