### PR TITLE
gh#197: Enable/Disable Continuous audio output mode

### DIFF
--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -1745,9 +1745,9 @@ dsError_t  dsGetSecondaryLanguage(intptr_t handle, char* sLang);
 dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int volume);
 
 /**
- * @brief  Enables or disables continuous audio output mode on a digital output port.
+ * @brief  Enables or disables continuous audio output mode on an ARC/eARC or SPDIF output port.
  *
- * When enabled, the MS12 continuously emits valid encoded frames
+ * When enabled, MS12 continuously emits valid encoded frames
  * (silent frames) in the currently-active output format on the digital output
  * interface whenever the input audio is briefly interrupted (for example during a
  * content/source transition within an application). This keeps the connected
@@ -1758,8 +1758,8 @@ dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int vol
  * if the port is presenting Dolby Digital Plus 5.1, the frames are valid Dolby
  * Digital Plus 5.1 silent frames), so the receiver lock is held.
  *
- * This setting applies to Auto mode is enabled on digital ports (ARC/eARC, SPDIF).
- * It is not applicable to non-digital port or speaker port, 
+ * This setting applies when Auto mode is enabled on digital ports (ARC/eARC, SPDIF).
+ * It is not applicable to non-digital ports or the speaker port,
  * for which the implementation returns dsERR_OPERATION_NOT_SUPPORTED.
  *
  * @param[in] handle  - A valid port handle for ARC/eARC or SPDIF audio port, as returned by dsGetAudioPort().
@@ -1788,10 +1788,12 @@ dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int vol
 dsError_t dsSetContinuousAudioOutputMode(intptr_t handle, bool enable);
 
 /**
- * @brief Gets the current continuous audio output mode setting for a digital output port.
+ * @brief Gets the current continuous audio output mode setting for an ARC/eARC or SPDIF output port.
  *
  * Returns whether continuous audio output mode (see dsSetContinuousAudioOutputMode())
- * is currently enabled on the given ARC/eARC or SPDIF output port.
+ * is currently enabled on the given ARC/eARC or SPDIF output port. This reflects the
+ * most recently requested value (including a value cached while in PCM/Passthrough),
+ * consistent with dsSetContinuousAudioOutputMode().
  *
  * @param[in]  handle  - Valid audio port handle for an ARC/eARC or SPDIF output port.
  * @param[out] enable  - Set to true if continuous audio output mode is enabled,

--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -1744,6 +1744,75 @@ dsError_t  dsGetSecondaryLanguage(intptr_t handle, char* sLang);
 */
 dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int volume);
 
+/**
+ * @brief  Enables or disables continuous audio output mode on a digital output port.
+ *
+ * When enabled, the MS12 continuously emits valid encoded frames
+ * (silent frames) in the currently-active output format on the digital output
+ * interface whenever the input audio is briefly interrupted (for example during a
+ * content/source transition within an application). This keeps the connected
+ * receiver/soundbar decoder and clock locked to the active format, preventing
+ * audible pops, mutes, or a format re-lock on the downstream device.
+ *
+ * The keep-alive frames MUST match the format currently presented on the port (e.g.
+ * if the port is presenting Dolby Digital Plus 5.1, the frames are valid Dolby
+ * Digital Plus 5.1 silent frames), so the receiver lock is held.
+ *
+ * This setting applies to Auto mode is enabled on digital ports (ARC/eARC, SPDIF).
+ * It is not applicable to non-digital port or speaker port, 
+ * for which the implementation returns dsERR_OPERATION_NOT_SUPPORTED.
+ *
+ * @param[in] handle  - A valid port handle for ARC/eARC or SPDIF audio port, as returned by dsGetAudioPort().
+ * @param[in] enable  - Continuous audio output mode ( @a true to enable  @a false to disable)
+ *
+ * @return dsError_t                      -  Status
+ * @retval dsERR_NONE                     -  Success
+ * @retval dsERR_NOT_INITIALIZED          -  Module is not initialised
+ * @retval dsERR_INVALID_PARAM            -  When handle is invalid or
+ *                                           Parameter passed to this function is invalid
+ * @retval dsERR_OPERATION_NOT_SUPPORTED  -  A valid handle on a non-digital port or Speaker port
+ *                                           or if platform/port does not support this mode.
+ * @retval dsERR_GENERAL                  -  Underlying undefined platform error
+ *
+ * @pre  dsAudioPortInit() and dsGetAudioPort() should be called before calling this API.
+ * @post The setting is not retained across dsAudioPortTerm() / power cycle,
+ *       Caller should re-apply it as needed.
+ * @note Default state is disabled for continuous audio output mode.
+ * @note If enable is true and the current audio mode is Passthrough or PCM then cache the setting,
+ *       return dsERR_NONE and apply it when auto is enabled.
+ * @note Idempotent - calling with the value already set returns dsERR_NONE.
+ * @warning  This API is Not thread safe.
+ * @see dsGetContinuousAudioOutputMode()
+ *
+ */
+dsError_t dsSetContinuousAudioOutputMode(intptr_t handle, bool enable);
+
+/**
+ * @brief Gets the current continuous audio output mode setting for a digital output port.
+ *
+ * Returns whether continuous audio output mode (see dsSetContinuousAudioOutputMode())
+ * is currently enabled on the given ARC/eARC or SPDIF output port.
+ *
+ * @param[in]  handle  - Valid audio port handle for an ARC/eARC or SPDIF output port.
+ * @param[out] enable  - Set to true if continuous audio output mode is enabled,
+ *                       false otherwise.
+ *
+ * @return dsError_t                      - Status
+ * @retval dsERR_NONE                     - Success
+ * @retval dsERR_NOT_INITIALIZED          - Module is not initialised
+ * @retval dsERR_INVALID_PARAM            - handle is invalid or enable is NULL
+ * @retval dsERR_OPERATION_NOT_SUPPORTED  - A valid handle on a non-digital port or Speaker port
+ *                                          or if platform/port does not support this mode.
+ * @retval dsERR_GENERAL                  - Underlying undefined platform error
+ *
+ * @pre  dsAudioPortInit() and dsGetAudioPort() must be called before this API.
+ * @note Default state is disabled for continuous audio output mode.
+ * @warning  This API is Not thread safe.
+ * @see dsSetContinuousAudioOutputMode()
+ *
+ */
+dsError_t dsGetContinuousAudioOutputMode(intptr_t handle, bool* enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -1762,8 +1762,7 @@ dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int vol
  * digital ports (ARC/eARC, SPDIF). It is not applicable to non-digital ports or the
  * speaker port, for which the implementation returns dsERR_OPERATION_NOT_SUPPORTED.
  *
- * @param[in] handle  - A valid handle for an ARC/eARC or SPDIF audio port
- *                      (dsAUDIOPORT_TYPE_HDMI_ARC or dsAUDIOPORT_TYPE_SPDIF), as returned by dsGetAudioPort().
+ * @param[in] handle  - A valid handle for an ARC/eARC or SPDIF output audio port, as returned by dsGetAudioPort().
  * @param[in] enable  - Continuous audio output mode ( @a true to enable, @a false to disable)
  *
  * @return dsError_t                      -  Status

--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -1758,12 +1758,13 @@ dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int vol
  * if the port is presenting Dolby Digital Plus 5.1, the frames are valid Dolby
  * Digital Plus 5.1 silent frames), so the receiver lock is held.
  *
- * This setting applies when Auto mode is enabled on digital ports (ARC/eARC, SPDIF).
- * It is not applicable to non-digital ports or the speaker port,
- * for which the implementation returns dsERR_OPERATION_NOT_SUPPORTED.
+ * This setting applies when Stereo Auto mode (see dsSetStereoAuto()) is enabled on
+ * digital ports (ARC/eARC, SPDIF). It is not applicable to non-digital ports or the
+ * speaker port, for which the implementation returns dsERR_OPERATION_NOT_SUPPORTED.
  *
- * @param[in] handle  - A valid port handle for ARC/eARC or SPDIF audio port, as returned by dsGetAudioPort().
- * @param[in] enable  - Continuous audio output mode ( @a true to enable  @a false to disable)
+ * @param[in] handle  - A valid handle for an ARC/eARC or SPDIF audio port
+ *                      (dsAUDIOPORT_TYPE_HDMI_ARC or dsAUDIOPORT_TYPE_SPDIF), as returned by dsGetAudioPort().
+ * @param[in] enable  - Continuous audio output mode ( @a true to enable, @a false to disable)
  *
  * @return dsError_t                      -  Status
  * @retval dsERR_NONE                     -  Success
@@ -1779,7 +1780,7 @@ dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int vol
  *       Caller should re-apply it as needed.
  * @note Default state is disabled for continuous audio output mode.
  * @note If enable is true and the current audio mode is Passthrough or PCM then cache the setting,
- *       return dsERR_NONE and apply it when auto is enabled.
+ *       return dsERR_NONE and apply it when Stereo Auto mode (dsSetStereoAuto()) is enabled.
  * @note Idempotent - calling with the value already set returns dsERR_NONE.
  * @warning  This API is Not thread safe.
  * @see dsGetContinuousAudioOutputMode()

--- a/include/dsAudio.h
+++ b/include/dsAudio.h
@@ -1770,7 +1770,7 @@ dsError_t dsSetAudioMixerLevels (intptr_t handle, dsAudioInput_t aInput, int vol
  * @retval dsERR_NOT_INITIALIZED          -  Module is not initialised
  * @retval dsERR_INVALID_PARAM            -  When handle is invalid or
  *                                           Parameter passed to this function is invalid
- * @retval dsERR_OPERATION_NOT_SUPPORTED  -  A valid handle on a non-digital port or Speaker port
+ * @retval dsERR_OPERATION_NOT_SUPPORTED  -  A valid handle on a non-digital port or speaker port
  *                                           or if platform/port does not support this mode.
  * @retval dsERR_GENERAL                  -  Underlying undefined platform error
  *
@@ -1803,11 +1803,11 @@ dsError_t dsSetContinuousAudioOutputMode(intptr_t handle, bool enable);
  * @retval dsERR_NONE                     - Success
  * @retval dsERR_NOT_INITIALIZED          - Module is not initialised
  * @retval dsERR_INVALID_PARAM            - handle is invalid or enable is NULL
- * @retval dsERR_OPERATION_NOT_SUPPORTED  - A valid handle on a non-digital port or Speaker port
+ * @retval dsERR_OPERATION_NOT_SUPPORTED  - A valid handle on a non-digital port or speaker port
  *                                          or if platform/port does not support this mode.
  * @retval dsERR_GENERAL                  - Underlying undefined platform error
  *
- * @pre  dsAudioPortInit() and dsGetAudioPort() must be called before this API.
+ * @pre  dsAudioPortInit() and dsGetAudioPort() should be called before calling this API.
  * @note Default state is disabled for continuous audio output mode.
  * @warning  This API is Not thread safe.
  * @see dsSetContinuousAudioOutputMode()


### PR DESCRIPTION
Introducing a new api in device settings to enable continuous audio output mode supported by MS12.