### PR TITLE
dsHdmiIn HAL API Documentation Improvements and Specification Clarifications

### DIFF
--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -614,7 +614,7 @@ dsError_t dsGetEDIDBytesInfo (dsHdmiInPort_t iHdmiPort, unsigned char *edid, int
  *
  * @param[in] iHdmiPort     - HDMI input port. Please refer ::dsHdmiInPort_t
  * @param[out] data         - HDMI SPD info data
- *                              Should not exceed sizeof(dsSpd_infoframe_st).  Please refer ::dsSpd_infoframe_st
+ *                              Please refer ::dsSpd_infoframe_st.
  *
  * @return dsError_t                        - Status
  * @retval dsERR_NONE                       - Success
@@ -628,7 +628,7 @@ dsError_t dsGetEDIDBytesInfo (dsHdmiInPort_t iHdmiPort, unsigned char *edid, int
  * @warning  This API is Not thread safe.
  * 
  */
-dsError_t dsGetHDMISPDInfo (dsHdmiInPort_t iHdmiPort, unsigned char *data);
+dsError_t dsGetHDMISPDInfo(dsHdmiInPort_t iHdmiPort, dsSpd_infoframe_st *spdInfo);
 
 /**
  * @brief Sets the EDID version to be used for a given port id
@@ -681,14 +681,14 @@ dsError_t dsSetEdidVersion (dsHdmiInPort_t iHdmiPort, tv_hdmi_edid_version_t iEd
 dsError_t dsGetEdidVersion (dsHdmiInPort_t iHdmiPort, tv_hdmi_edid_version_t *iEdidVersion);
 
 /**
- * @brief Checks whether ALLM status is enabled or disabled for the specific HDMI input port
+ * @brief Gets the current ALLM status for the specified HDMI input port
  * 
- * For sink devices, this function checks whether ALLM status is enabled or disabled for the specific HDMI input port.
+ * For sink devices, this function checks whether ALLM status is enabled or disabled for the specified HDMI input port.
  * For source devices, this function returns dsERR_OPERATION_NOT_SUPPORTED always.
  *
  * @param[in] iHdmiPort     - HDMI input port.  Please refer ::dsHdmiInPort_t
- * @param[out] allmStatus   - Flag to control the allm status
- *                              ( @a true to enable, @a false to disable)
+ * @param[out] allmStatus   - ALLM status of the specified HDMI input port
+ *                              ( @a true if ALLM is enabled, @a false if ALLM is disabled)
  *
  * @return dsError_t                        - Status
  * @retval dsERR_NONE                       - Success

--- a/include/dsHdmiIn.h
+++ b/include/dsHdmiIn.h
@@ -155,7 +155,7 @@ dsError_t dsHdmiInTerm (void);
  * @retval dsERR_NONE                       - Success
  * @retval dsERR_NOT_INITIALIZED            - Module is not initialised
  * @retval dsERR_INVALID_PARAM              - Parameter passed to this function is invalid
- * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported; e.g: source devices
+ * @retval dsERR_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported
  * @retval dsERR_OPERATION_FAILED           - The attempted operation has failed
  * 
  * @pre dsHdmiInInit() must be called before calling this API.


### PR DESCRIPTION
**Goal**
Improve HAL API specification clarity, consistency, and usability by addressing ambiguous documentation, refining parameter descriptions, and explicitly defining expected API behavior to prevent implementation and integration inconsistencies.

**API: dsHdmiInGetNumberOfInputs()**

**Issue Description**
 The current specification states that source devices without HDMI input support "return 0", which is ambiguous. It is unclear whether this means:

The API returns dsERR_NONE and sets *NoOfinputs = 0, or
The API returns dsERR_OPERATION_NOT_SUPPORTED.

The specification should explicitly define the expected return status and output parameter behavior.

**API: dsGetHDMISPDInfo()**

**Issue Description**
 The API uses unsigned char *data as the output parameter, while the documentation refers to dsSpd_infoframe_st and its size. This creates ambiguity regarding expected buffer size and data format. The specification should update the API to use dsSpd_infoframe_st * as the output parameter and document that the SPD information is returned through this structure.

**API: dsGetAllmStatus()**

**Issue Description**
 The current documentation describes allmStatus as a "Flag to control the ALLM status". Since this is a getter API, the parameter does not control ALLM; it reports the current ALLM state. The specification should update the parameter description to indicate that it returns the current ALLM status of the specified HDMI input port.